### PR TITLE
Fix constant endowments

### DIFF
--- a/src/safeEvaluator.js
+++ b/src/safeEvaluator.js
@@ -94,9 +94,10 @@ export function createSafeEvaluatorFactory(
         sloppyGlobalsMode
       );
       const scopeProxyRevocable = proxyRevocable(immutableObject, scopeHandler);
-
-      const scopedEvaluator = apply(scopedEvaluatorFactory, safeGlobal, [
-        scopeProxyRevocable.proxy
+      const scopeProxy = scopeProxyRevocable.proxy;
+      
+      const scopedEvaluator = apply(scopedEvaluatorFactory, scopeProxy, [
+        scopeProxy
       ]);
 
       scopeHandler.useUnsafeEvaluator = true;

--- a/test/module/optimizer.js
+++ b/test/module/optimizer.js
@@ -1,34 +1,34 @@
 import test from 'tape';
-import { getOptimizableGlobals } from '../../src/optimizer';
+import { getOptimizableConstants } from '../../src/optimizer';
 
-test('getOptimizableGlobals', t => {
+test('getOptimizableConstants', t => {
   t.plan(20);
 
   t.deepEqual(
-    getOptimizableGlobals({}),
+    getOptimizableConstants({}),
     [],
     'should return empty if no global'
   );
 
   t.deepEqual(
-    getOptimizableGlobals({ foo: true }),
+    getOptimizableConstants({ foo: true }),
     [],
     'should reject configurable & writable'
   );
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { foo: { value: true } })),
+    getOptimizableConstants(Object.create(null, { foo: { value: true } })),
     ['foo'],
     'should return non configurable & non writable'
   );
   t.deepEqual(
-    getOptimizableGlobals(
+    getOptimizableConstants(
       Object.create(null, { foo: { value: true, configurable: true } })
     ),
     [],
     'should reject configurable'
   );
   t.deepEqual(
-    getOptimizableGlobals(
+    getOptimizableConstants(
       Object.create(null, { foo: { value: true, writable: true } })
     ),
     [],
@@ -36,28 +36,28 @@ test('getOptimizableGlobals', t => {
   );
 
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { foo: { get: () => true } })),
+    getOptimizableConstants(Object.create(null, { foo: { get: () => true } })),
     [],
     'should reject getter'
   );
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { foo: { set: () => true } })),
+    getOptimizableConstants(Object.create(null, { foo: { set: () => true } })),
     [],
     'should reject setter'
   );
 
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { eval: { value: true } })),
+    getOptimizableConstants(Object.create(null, { eval: { value: true } })),
     [],
     'should reject eval'
   );
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { const: { value: true } })),
+    getOptimizableConstants(Object.create(null, { const: { value: true } })),
     [],
     'should reject reserved keyword'
   );
   t.deepEqual(
-    getOptimizableGlobals(
+    getOptimizableConstants(
       Object.create(null, {
         null: { value: true },
         true: { value: true },
@@ -68,14 +68,14 @@ test('getOptimizableGlobals', t => {
     'should reject literals (reserved)'
   );
   t.deepEqual(
-    getOptimizableGlobals(
+    getOptimizableConstants(
       Object.create(null, { this: { value: true }, arguments: { value: true } })
     ),
     [],
     'should reject this and arguments'
   );
   t.deepEqual(
-    getOptimizableGlobals(
+    getOptimizableConstants(
       Object.create(null, { [Symbol.iterator]: { value: true } })
     ),
     [],
@@ -83,46 +83,46 @@ test('getOptimizableGlobals', t => {
   );
 
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { 123: { value: true } })),
+    getOptimizableConstants(Object.create(null, { 123: { value: true } })),
     [],
     'should reject leading digit'
   );
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { '-123': { value: true } })),
+    getOptimizableConstants(Object.create(null, { '-123': { value: true } })),
     [],
     'should reject leading dash'
   );
 
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { _123: { value: true } })),
+    getOptimizableConstants(Object.create(null, { _123: { value: true } })),
     ['_123'],
     'should return leading underscore'
   );
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { $123: { value: true } })),
+    getOptimizableConstants(Object.create(null, { $123: { value: true } })),
     ['$123'],
     'should return leading underscore'
   );
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { a123: { value: true } })),
+    getOptimizableConstants(Object.create(null, { a123: { value: true } })),
     ['a123'],
     'should return leading lowercase'
   );
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { A123: { value: true } })),
+    getOptimizableConstants(Object.create(null, { A123: { value: true } })),
     ['A123'],
     'should return leading uppercase'
   );
 
   t.deepEqual(
-    getOptimizableGlobals(
+    getOptimizableConstants(
       Object.create(null, { foo: { value: true }, bar: { value: true } })
     ),
     ['foo', 'bar'],
     'should return all non configurable & non writable'
   );
   t.deepEqual(
-    getOptimizableGlobals(
+    getOptimizableConstants(
       Object.create(null, {
         foo: { value: true },
         bar: { value: true, configurable: true }


### PR DESCRIPTION
Fixes #2 

As reported by @XmiliaH at #2 code such as 

```js
const Marker = "Marker";
new Evaluator().evaluate("bad", Object.create(null, {bad: {value: Marker}}))
```

fails to look up the value of "bad" on the endowment. This is due to conflicting assumptions in the code. Historically, we assumed that we were only optimizing optimizable own properties of the `safeGlobal`. Now that we're building optimizing code per evaluation, it makes sense to extend the optimization to include optimizable own properties of the endowments as well. The refactoring to extend this optimization missed a crucial step: passing the scopeProxy in as the object from which to extract the constant values, rather than passing in the `safeGlobal`. 

This way of repairing the refactoring does cause a proxy trap per optimizable global per evaluation. If this proves expensive, we could pass both the `safeGlobal` and the `endowments` directly into the generated optimizer code, as long as we pass them in without introducing more names into scope. `arguments[1]` and `arguments[2]` would work.

Note that either way of completing the refactoring introduces a hazard. Neither the `scopeProxy` (in the first technique) nor the `endowments` object itself (in the second technique) may leak into user code. They both must be completely encapsulated by the shim. Making them available in the enclosing scope of the eval-ed code makes their encapsulation hard to verify. Such verification would need to reason about all the odd corners of `with` and sloppy-mode declarations.